### PR TITLE
Change _all_docs path to byId view

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN mvn package -q
 
 FROM openjdk:10-slim
 COPY --from=build /build/target/*.jar /app/
-COPY --from=build /build/target/lib /app/lib
 
 WORKDIR /app
 EXPOSE 80

--- a/src/main/java/de/hampager/dapnet/service/database/AbstractController.java
+++ b/src/main/java/de/hampager/dapnet/service/database/AbstractController.java
@@ -91,9 +91,10 @@ abstract class AbstractController {
 		return auth.authenticate(authreq);
 	}
 
-	protected URI buildAllDocsPath(Map<String, String> requestParams) {
+	protected URI buildViewPath(String designDoc, String viewName, Map<String, String> requestParams) {
 		UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath);
-		builder.path("_all_docs").queryParam("include_docs", "true").queryParam("limit", "20");
+		builder.path("_design/" + designDoc + "/_view/" + viewName);
+		builder.queryParam("include_docs", "true").queryParam("limit", "20");
 
 		if (requestParams.containsKey("startswith")) {
 			String value = requestParams.remove("startswith");

--- a/src/main/java/de/hampager/dapnet/service/database/UserController.java
+++ b/src/main/java/de/hampager/dapnet/service/database/UserController.java
@@ -63,7 +63,7 @@ class UserController extends AbstractController {
 	public ResponseEntity<JsonNode> getAll(Authentication authentication, @RequestParam Map<String, String> params) {
 		ensureAuthenticated(authentication, USER_READ);
 
-		URI path = buildAllDocsPath(params);
+		URI path = buildViewPath("users", "byId", params);
 		JsonNode in = restTemplate.getForObject(path, JsonNode.class);
 		ObjectNode out = mapper.createObjectNode();
 


### PR DESCRIPTION
Der `/_all_docs` Endpunkt von CouchDB gibt leider auch die Design-Dokumente mit aus. Deshalb müssen die Objekte über einen View abgerufen werden. Für die User liegt der unter `/users/_design/users/_view/byId`.